### PR TITLE
Exclude event, event worker and event actions.

### DIFF
--- a/src/Graviton/AuditTrackingBundle/Resources/config/parameters.yml
+++ b/src/Graviton/AuditTrackingBundle/Resources/config/parameters.yml
@@ -25,4 +25,4 @@ parameters:
         # Exclude header status exceptions code, 400=bad request, form validation
         exceptions_exclude: [400]
         # Exclude listed URLS, array
-        exclude_urls: ["/auditing"]
+        exclude_urls: ["/auditing", "/event/"]


### PR DESCRIPTION
To avoid overload of un-needed tracking.